### PR TITLE
Anchored and start at

### DIFF
--- a/src/commonMain/kotlin/com/meamoria/lexurgy/sc/SoundChanger.kt
+++ b/src/commonMain/kotlin/com/meamoria/lexurgy/sc/SoundChanger.kt
@@ -186,7 +186,9 @@ class SoundChanger(
         val indexToDebugWords: Map<Int, String>,
     ) {
         init {
-            debug("Tracing ${indexToDebugWords.values.joinToString(", ")}")
+            if (indexToDebugWords.isNotEmpty()) {
+                debug("Tracing ${indexToDebugWords.values.joinToString(", ")}")
+            }
         }
         operator fun invoke(
             name: String,

--- a/src/commonMain/kotlin/com/meamoria/lexurgy/sc/SoundChanger.kt
+++ b/src/commonMain/kotlin/com/meamoria/lexurgy/sc/SoundChanger.kt
@@ -76,6 +76,9 @@ class SoundChanger(
         fun runAnchoredStep(anchoredStep: AnchoredStep) {
             when (anchoredStep) {
                 is IntermediateRomanizerStep -> {
+                    if (!started) {
+                        return
+                    }
                     val rom = anchoredStep.romanizer
                     result[rom.name] = applyRule(
                         maybeReplace(rom), words, curPhrases, tracer
@@ -83,6 +86,9 @@ class SoundChanger(
                 }
 
                 is CleanupStep -> {
+                    if (!started) {
+                        return
+                    }
                     curPhrases = applyRule(
                         anchoredStep.cleanupRule, words, curPhrases, tracer
                     )
@@ -93,6 +99,9 @@ class SoundChanger(
                 }
 
                 is SyllabificationStep -> {
+                    if (!started) {
+                        return
+                    }
                     curPhrases = applySyllables(
                         anchoredStep.declarations, curPhrases, tracer
                     )
@@ -102,6 +111,10 @@ class SoundChanger(
 
         for (ruleWithAnchoredSteps in rules) {
             val rule = ruleWithAnchoredSteps.rule
+
+            if (!started && (startAt == null || rule?.name == startAt)) {
+                started = true
+            }
 
             for (anchoredStep in persistentEffects.cleanupRules) {
                 // Always run persistent cleanup rules first.
@@ -140,9 +153,6 @@ class SoundChanger(
                 break
             }
 
-            if (!started && (startAt == null || rule?.name == startAt)) {
-                started = true
-            }
             if (started) {
                 if (rule != null && (romanize || rule.ruleType != RuleType.ROMANIZER)) {
                     curPhrases = applyRule(

--- a/src/commonTest/kotlin/com/meamoria/lexurgy/sc/TestSyllables.kt
+++ b/src/commonTest/kotlin/com/meamoria/lexurgy/sc/TestSyllables.kt
@@ -917,6 +917,44 @@ class TestSyllables : StringSpec({
         )
     }
 
+    "Start-at should not run earlier anchored steps, but still keep them" {
+        val ch = lsc(
+            """
+                    syllables:
+                        C V+
+                        
+                    clusters cleanup:
+                        C => * / $ _ C
+                        
+                    hiatus cleanup:
+                        V => * / V _
+                        
+                    syllables:
+                        C V
+                    
+                    rule1:
+                        C => C C / $ _
+                        
+                    syllables:
+                        C C V
+                        C V
+                        
+                    clusters:
+                        off
+                        
+                    another-rule:
+                        unchanged
+                        
+                    rule2:
+                        unchanged
+                        
+                """.trimIndent()
+        )
+
+        ch.change(listOf("CVCV")) shouldBe listOf("CV.CV")
+        ch.change(listOf("CCVCVV"), startAt = "rule2") shouldBe listOf("CCV.CV")
+    }
+
     "Unbounded syllable repeaters should be able to process empty words" {
         val ch = lsc(
             """

--- a/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSoundChangerWithFiles.kt
+++ b/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSoundChangerWithFiles.kt
@@ -10,6 +10,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.time.ExperimentalTime
 
+@Suppress("unused")
 @ExperimentalTime
 class TestSoundChangerWithFiles : StringSpec({
     fun pathOf(vararg pathComponents: String): Path =
@@ -45,6 +46,19 @@ class TestSoundChangerWithFiles : StringSpec({
         val syllabianChanger =  soundChangerFromLscFile(pathOf("syllabian.lsc"))
         syllabianChanger.changeFiles(listOf(pathOf("proto-syllabian.wli")), debugWords=listOf("karapuna", "pana"))
         listFrom("proto-syllabian_trace.wli") shouldBe listFrom("proto-syllabian_trace_many_expected.wli")
+    }
+
+    "A sound changer should not produce a trace file when not tracing" {
+        val syllabianChanger =  soundChangerFromLscFile(pathOf("syllabian.lsc"))
+        val traceFile = pathOf("proto-syllabian_trace.wli").toFile()
+
+        if (traceFile.exists() && traceFile.isFile) {
+            pathOf("proto-syllabian_trace.wli").toFile().delete()
+        }
+
+        syllabianChanger.changeFiles(listOf(pathOf("proto-syllabian.wli")))
+
+        pathOf("proto-syllabian_trace.wli").toFile().exists() shouldBe false
     }
 
     "The --compare-stages setting should print the original in a wlm file" {


### PR DESCRIPTION
Hey Graham, another small PR:
- Small fix for the tracing headline, that was always printed (even when there were no debug words)
- Anchored steps and start-at.

Consider the changes:
```
syllables: # 1
    C V+
    
clusters cleanup:
    C => * / $ _ C
    
hiatus cleanup:
    V => * / V _
    
syllables: # 2
    C V

rule1:
    C => C C / $ _
    
syllables: # 3
    C C V
    C V
    
clusters:
    off
    
another-rule:
    unchanged
    
rule2:
    unchanged
```

For the input `CCVCV` and `startAt=rule2` the expected output (I would think) is `CCV.CV`.
Lexurgy currently throws a syllabification error (as far as I can tell, it tries to apply both `# 1` and `# 2`, in order).
This fixes it, and also ensures that cleanup rules that aren't be relevant starting at `rule2` will not be applied.

There is still a small issue with `CleanupOff` rules anchored at the rule Lexurgy starts at. 
Without `another-rule` between the `clusters: off` and `rule2`, the output is `CV.CV`.
I could try to fix that, but I'm not sure what the intended semantics are - let me know.