### PR TITLE
Allow file inclusions in sound changes file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ hs_err_pid*
 
 /test/*_ev.*
 /test/*/*
+!/test/sound_changes/*
 /doc/build/*
 /doc/build-public/*
 /.idea/artifacts/

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/sc/SoundChangerJvm.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/sc/SoundChangerJvm.kt
@@ -6,7 +6,6 @@ import java.nio.file.Path
 import kotlin.streams.toList
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
-import kotlin.time.TimedValue
 import kotlin.time.measureTimedValue
 
 @ExperimentalTime
@@ -44,7 +43,9 @@ fun changeFiles(
 }
 
 fun soundChangerFromLscFile(path: Path): SoundChanger =
-    SoundChanger.fromLsc(path.toFile().readLines().joinToString("\n"))
+    SoundChanger.fromLsc(SoundChangesFileLoader().load(path).joinToString("\n"))
+
+
 
 @ExperimentalTime
 fun SoundChanger.changeFiles(

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/sc/SoundChangesFileLoader.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/sc/SoundChangesFileLoader.kt
@@ -1,0 +1,36 @@
+package com.meamoria.lexurgy.sc
+
+import com.meamoria.lexurgy.LscUserError
+import java.nio.file.Path
+
+
+class CircularInclusion(path: Path) : LscUserError(
+    "File ${path.fileName} has a circular inclusion"
+)
+
+class SoundChangesFileLoader {
+    companion object {
+        val INCLUDE_LINE = Regex("^\\s*#include\\s+\"(.+?)\"\\s*$")
+    }
+
+    val pathsVisited: MutableSet<Path> = mutableSetOf()
+
+    fun load(path: Path): Sequence<String> {
+        if (path in pathsVisited) {
+            throw CircularInclusion(path)
+        }
+        pathsVisited.add(path)
+
+        return sequence {
+            for (line in path.toFile().readLines()) {
+                val match = INCLUDE_LINE.find(line)
+                if (match == null) {
+                    yield(line)
+                    continue
+                }
+                val includedPath = match.groupValues[1]
+                yieldAll(load(path.parent.resolve(includedPath)))
+            }
+        }
+    }
+}

--- a/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSoundChangerWithIncludedFiles.kt
+++ b/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSoundChangerWithIncludedFiles.kt
@@ -1,0 +1,41 @@
+package com.meamoria.lexurgy.sc
+
+import com.meamoria.lexurgy.dumpList
+import com.meamoria.lexurgy.loadList
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import kotlin.time.ExperimentalTime
+
+@Suppress("unused")
+@ExperimentalTime
+class TestSoundChangerWithIncludedFiles : StringSpec({
+    fun pathOf(vararg pathComponents: String): Path =
+        FileSystems.getDefault().getPath("test", *pathComponents)
+
+    fun listFrom(vararg pathComponents: String): List<String> =
+        loadList(pathOf(*pathComponents))
+
+    fun listTo(words: List<String>, vararg pathComponents: String) =
+        dumpList(pathOf(*pathComponents), words)
+
+    fun prepareOutDir(outDir: String): String {
+        val outFolder = pathOf(outDir).toFile()
+        outFolder.deleteRecursively()
+        outFolder.mkdir()
+        return outDir
+    }
+
+    val changer = soundChangerFromLscFile(pathOf("muipidan_includer.lsc"))
+
+    "A sound changer with included files should be able to process some wordlists" {
+        val outDir = prepareOutDir("basic")
+        changer.changeFiles(
+            listOf(pathOf("ptr_test_1.wli"), pathOf("ptr_test_2.wli")),
+            outDir = outDir,
+        )
+        listFrom(outDir, "ptr_test_1_ev.wli") shouldBe listFrom("ptr_test_1_ev_expected.wli")
+        listFrom(outDir, "ptr_test_2_ev.wli") shouldBe listFrom("ptr_test_2_ev_expected.wli")
+    }
+})

--- a/test/muipidan_includer.lsc
+++ b/test/muipidan_includer.lsc
@@ -1,0 +1,1 @@
+#include "sound_changes/muipidan_included.lsc"

--- a/test/sound_changes/muipidan_definitions.lsc
+++ b/test/sound_changes/muipidan_definitions.lsc
@@ -1,0 +1,45 @@
+Feature Type(*cons, vowel)
+Feature Place(lab, apic, vel, glot)
+Feature Manner(stop, fric, sonor)
+Feature Nasal(*unnas, nas)
+Feature Breath(unvcd, vcd, aspir, eject)
+Feature Height(high, low)
+Feature Depth(front, cent, back)
+Feature Rounding(*unrnd, rnd)
+Feature Stress(*unstr, str)
+
+Diacritic ˈ (before) [str]
+Diacritic ʼ [eject]
+Diacritic ʰ [aspir]
+Diacritic ̥  [unvcd]
+
+Symbol p [stop unvcd lab]
+Symbol t [stop unvcd apic]
+Symbol k [stop unvcd vel]
+Symbol ʔ [stop unvcd glot]
+Symbol b [stop vcd lab]
+Symbol d [stop vcd apic]
+Symbol g [stop vcd vel]
+Symbol ᵐb [stop nas vcd lab]
+Symbol ⁿd [stop nas vcd apic]
+Symbol ᵑg [stop nas vcd vel]
+Symbol f [fric lab]
+Symbol s [fric apic]
+Symbol x [fric vel]
+Symbol h [fric glot]
+Symbol m [sonor nas vcd lab]
+Symbol n [sonor nas vcd apic]
+Symbol l [sonor apic]
+Symbol j [sonor high front unrnd]
+Symbol w [sonor high back rnd]
+
+Symbol i [vowel high front]
+Symbol e [vowel low front]
+Symbol y [vowel high front rnd]
+Symbol ø [vowel low front rnd]
+Symbol ə [vowel high cent]
+Symbol a [vowel low cent]
+Symbol ɯ [vowel high back]
+Symbol ɤ [vowel low back]
+Symbol u [vowel high back rnd]
+Symbol o [vowel low back rnd]

--- a/test/sound_changes/muipidan_included.lsc
+++ b/test/sound_changes/muipidan_included.lsc
@@ -1,0 +1,84 @@
+#include "./muipidan_definitions.lsc"
+
+Deromanizer:
+    c => x
+    ' => ʔ
+    á => ˈa
+    é => ˈe
+    í => ˈi
+    ó => ˈo
+    ú => ˈu
+
+first-syllable-stress [vowel]:
+    [] => [str] / $ _ [unstr]+ $
+
+syncope [vowel]:
+    [] => * / {_ [str], [str] _ []}
+
+# We now have predictable word-initial stress
+remove-stress:
+    [str] => [unstr]
+
+consonant-coalescence:
+    [stop !glot] [stop] => [eject] * / _ [vowel]
+    [stop !glot] [fric] => [aspir] * / _ [vowel]
+    [nas] [stop] => * [nas vcd]
+    [fric] [nas] => * [unvcd]
+    [nas] [fric] => [unvcd] *
+
+stop-voicing:
+    [stop !glot !eject !aspir] => [vcd] / [vowel] _ [vowel]
+
+cluster-reduction:
+    [nas] => * / $ _ [fric]
+    l => * / $ _ [cons]
+    [stop] => * / _ [stop]
+    n => l / [stop] _
+    [fric] => * / _ [stop]
+
+nasal-assimilation:
+    [nas] => [$Place] / _ [cons $Place]
+    n => l / _ l
+
+glottal-loss:
+    [glot] => *
+    [vowel high] => [cons sonor] / {_ [vowel], [vowel] _}
+
+vowel-harmony-by-height [vowel] propagate:
+    [vowel] => [$Height] / [vowel $Height] _
+
+final-vowel-loss:
+    [vowel] => * / [vowel] [cons !stop] _ $
+    {e, ə, u} => {i, a, o} / [vowel] [cons]* _ $
+
+coda-l:
+    l => j / _ [cons] // _ [sonor unnas]
+    l [vowel] => j * / [vowel] [cons]* [vowel] _ [cons]+ [vowel]
+
+vowel-harmony-by-frontness [vowel] propagate:
+    [vowel !cent] => [$Depth] / [vowel !cent $Depth] [vowel cent]* _
+
+vowel-mergers:
+    {ø, ɤ, ə, ɯ} => {y, ɨ, ɨ, ɨ} // _ $
+    {ø, ɯ} => {ə, ə} / _ $
+
+velar-fricative:
+    x => h
+
+Romanizer:
+    pʼ => p'
+    tʼ => t'
+    kʼ => k'
+    pʰ => ph
+    tʰ => th
+    kʰ => kh
+    ᵐb => mb
+    ⁿd => nd
+    ᵑg => ng
+    m̥ => hm
+    n̥ => hn
+    ə => e
+    j => y
+    y => ü
+    ɨ => ï
+    f => v / {[vowel], [sonor]} _ {[vowel], [sonor]}


### PR DESCRIPTION
Hey Graham, this allows sound changes files to include other files (relative to them). The syntax is `#include "..."`.

Let me know if anything's missing from the PR.

Thanks!