### PR TITLE
Lexurgy Server Mode

### DIFF
--- a/.idea/runConfigurations/ConsoleTest.xml
+++ b/.idea/runConfigurations/ConsoleTest.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="ConsoleTest" type="JetRunConfigurationType">
     <option name="MAIN_CLASS_NAME" value="com.meamoria.lexurgy.MainJvmKt" />
     <module name="lexurgy.jvmMain" />
-    <option name="PROGRAM_PARAMETERS" value="sc test/nitherwe.lsc test/pn_finite_verbs.wli -t yuldi" />
+    <option name="PROGRAM_PARAMETERS" value="server test/nitherwe.lsc test/pn_finite_verbs.wli -t yuldi" />
     <shortenClasspath name="NONE" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.idea/runConfigurations/Console_SC_Test.xml
+++ b/.idea/runConfigurations/Console_SC_Test.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="ConsoleTest" type="JetRunConfigurationType">
+  <configuration default="false" name="Console SC Test" type="JetRunConfigurationType" folderName="Console Tests">
     <option name="MAIN_CLASS_NAME" value="com.meamoria.lexurgy.MainJvmKt" />
     <module name="lexurgy.jvmMain" />
     <option name="PROGRAM_PARAMETERS" value="server test/nitherwe.lsc test/pn_finite_verbs.wli -t yuldi" />

--- a/.idea/runConfigurations/Console_Server_Test.xml
+++ b/.idea/runConfigurations/Console_Server_Test.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Console Server Test" type="JetRunConfigurationType" folderName="Console Tests">
+    <option name="MAIN_CLASS_NAME" value="com.meamoria.lexurgy.MainJvmKt" />
+    <module name="lexurgy.jvmMain" />
+    <option name="PROGRAM_PARAMETERS" value="server test/nitherwe.lsc" />
+    <shortenClasspath name="NONE" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.meamoria'
-version '1.2.2-server'
+version '1.2.2'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.meamoria'
-version '1.2.2'
+version '1.2.2-server'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'org.jetbrains.kotlin.multiplatform' version '1.7.20'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.20'
     id 'application'
 }
 
@@ -90,6 +91,7 @@ kotlin {
                 implementation "com.github.ajalt:clikt:2.7.0"
                 implementation "net.java.dev.jna:jna:5.5.0"
                 implementation "net.java.dev.jna:jna-platform:5.5.0"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1"
             }
         }
         jvmTest {

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/MainJvm.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/MainJvm.kt
@@ -12,7 +12,6 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.path
 import com.meamoria.lexurgy.sc.LscRuleCrashed
 import com.meamoria.lexurgy.sc.changeFiles
-import com.meamoria.lexurgy.sc.soundChangerFromLscFile
 import com.meamoria.lexurgy.server.runServer
 import java.io.IOException
 import java.io.PrintWriter
@@ -135,7 +134,7 @@ class SC : CliktCommand(
 }
 
 class Server : CliktCommand(
-    help = "Applies sound changes from CHANGES (a .lsc file) to the words in stdin and outputs to stdout. "
+    help = "Applies sound changes from CHANGES (a .lsc file) to the words in stdin and outputs to stdout."
 ) {
     val changes by argument().path(mustBeReadable = true)
 

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/MainJvm.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/MainJvm.kt
@@ -15,7 +15,6 @@ import com.meamoria.lexurgy.sc.changeFiles
 import com.meamoria.lexurgy.sc.soundChangerFromLscFile
 import java.io.IOException
 import java.io.PrintWriter
-import kotlin.system.exitProcess
 import kotlin.time.ExperimentalTime
 
 class Lexurgy : CliktCommand() {
@@ -141,7 +140,7 @@ class Server : CliktCommand(
 
     @ExperimentalTime
     override fun run() {
-        console("Loading sound changes from $changes")
+        console("; Loading sound changes from $changes")
         val changer = soundChangerFromLscFile(changes)
         try {
             val words = mutableListOf<String>()
@@ -150,16 +149,16 @@ class Server : CliktCommand(
             var stopBefore: String? = null
             var romanize = true
             while (true) {
-                val line = readLine() ?: break
+                val line = readlnOrNull() ?: break
 
                 if (line.trim() == "; exit") {
                     break
                 }
 
                 if (line.isBlank()) {
-                    println("start=$startAt stop=$stopBefore romanize=$romanize")
+                    println("; start=$startAt stop=$stopBefore romanize=$romanize")
                     words.forEach {
-                        println("$it trace=${it in traceWords}")
+                        println("; $it trace=${it in traceWords}")
                     }
 
                     changer.change(
@@ -167,6 +166,8 @@ class Server : CliktCommand(
                     ).forEach {
                         println(it)
                     }
+
+                    println("; done")
 
                     words.clear()
                     traceWords.clear()

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/MainJvm.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/MainJvm.kt
@@ -134,7 +134,11 @@ class SC : CliktCommand(
 }
 
 class Server : CliktCommand(
-    help = "Applies sound changes from CHANGES (a .lsc file) to the words in stdin and outputs to stdout."
+    help = "Applies sound changes from CHANGES (a .lsc file) to the words in stdin and outputs to stdout. " +
+            "To apply sound changes, input a " +
+            "{\"type\": \"changes\", \"words\": [\"<WORD 1>\", \"<WORD 2>\", ...]} " +
+            "request. " +
+            "See documentation for full overview."
 ) {
     val changes by argument().path(mustBeReadable = true)
 

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/server/Server.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/server/Server.kt
@@ -1,0 +1,58 @@
+package com.meamoria.lexurgy.server
+
+import com.meamoria.lexurgy.ConsoleWriter
+import com.meamoria.lexurgy.console
+import com.meamoria.lexurgy.sc.LscRuleCrashed
+import com.meamoria.lexurgy.sc.soundChangerFromLscFile
+import kotlinx.serialization.Contextual
+import java.nio.file.Path
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.PrintWriter
+import java.io.StringWriter
+
+@Serializable
+data class ServerRequest(
+    val words: List<String>,
+    val startAt: String? = null,
+    val stopBefore: String? = null,
+    val debugWords: List<String> = emptyList(),
+    val romanize: Boolean = true
+)
+
+@Serializable
+data class ServerResponse(
+    val words: List<String>, val traceLines: List<String>
+)
+
+@Serializable
+data class ServerErrorResponse(
+    val message: String, val stackTrace: List<String>
+)
+
+data class StringCollector(val strings: MutableList<String> = mutableListOf()) : (String) -> Unit {
+    override fun invoke(string: String) {
+        strings.add(string)
+    }
+}
+
+fun runServer(changes: Path) {
+    val changer = soundChangerFromLscFile(changes)
+
+    while (true) {
+        val line = readlnOrNull() ?: break
+        val query = Json.decodeFromString<ServerRequest>(line)
+        val collector = StringCollector()
+        try {
+            val words = changer.change(
+                query.words, query.startAt, query.stopBefore, query.debugWords, query.romanize, collector
+            )
+            println(Json.encodeToString(ServerResponse(words, collector.strings)))
+        } catch (e: Exception) {
+            val message = e.message.toString()
+            val stackTrace = e.stackTrace.map { it.toString() }
+            println(Json.encodeToString(ServerErrorResponse(message, stackTrace)))
+        }
+    }
+}

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/server/Server.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/server/Server.kt
@@ -11,7 +11,7 @@ data class ServerRequest(
     val words: List<String>,
     val startAt: String? = null,
     val stopBefore: String? = null,
-    val debugWords: List<String> = emptyList(),
+    val traceWords: List<String> = emptyList(),
     val romanize: Boolean = true
 )
 
@@ -42,7 +42,7 @@ fun runServer(changes: Path) {
         val collector = StringCollector()
         try {
             val intermediates = changer.changeWithIntermediates(
-                query.words, query.startAt, query.stopBefore, query.debugWords, query.romanize, collector
+                query.words, query.startAt, query.stopBefore, query.traceWords, query.romanize, collector
             )
             val words = intermediates[null]!!
 

--- a/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSCModeCLI.kt
+++ b/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSCModeCLI.kt
@@ -12,7 +12,7 @@ import kotlin.time.ExperimentalTime
 
 @Suppress("unused")
 @ExperimentalTime
-class TestCLI : StringSpec({
+class TestSCModeCLI : StringSpec({
     fun pathOf(vararg pathComponents: String): Path =
         FileSystems.getDefault().getPath("test", *pathComponents)
 

--- a/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestServerModeCLI.kt
+++ b/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestServerModeCLI.kt
@@ -1,0 +1,78 @@
+package com.meamoria.lexurgy.sc
+
+import com.meamoria.lexurgy.lexurgyCommand
+import com.meamoria.lexurgy.loadList
+import com.meamoria.lexurgy.server.ServerRequest
+import com.meamoria.lexurgy.server.ServerResponse
+import kotlinx.serialization.json.Json
+import com.meamoria.mpp.kotest.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.encodeToString
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import kotlin.time.ExperimentalTime
+
+@Suppress("unused")
+@ExperimentalTime
+class TestServerModeCLI : StringSpec({
+    fun pathOf(vararg pathComponents: String): Path = FileSystems.getDefault().getPath("test", *pathComponents)
+
+    fun listFrom(vararg pathComponents: String): List<String> = loadList(pathOf(*pathComponents))
+
+    fun withStd(input: String, block: () -> Unit): String {
+        val oldOut = System.out
+        val oldIn = System.`in`
+        val outStream = ByteArrayOutputStream()
+        val inStream = ByteArrayInputStream(input.toByteArray())
+        outStream.use { openedOut ->
+            PrintStream(openedOut).use { printOut ->
+                System.setOut(printOut)
+                inStream.use {
+                    System.setIn(it)
+                    block()
+                    System.setIn(oldIn)
+                }
+                System.setOut(oldOut)
+            }
+        }
+        return outStream.toString()
+    }
+
+    fun runServer(changes: String, request: ServerRequest): ServerResponse {
+        val response = withStd(Json.encodeToString(request)) {
+            lexurgyCommand.parse(arrayOf("server", changes))
+        }
+        return Json.decodeFromString<ServerResponse>(response)
+    }
+
+    "Server mode can do sound changes from a request" {
+        val response = runServer("test/muipidan.lsc", ServerRequest(listFrom("ptr_test_1.wli")))
+        response.shouldBeInstanceOf<ServerResponse.Changed>()
+        response.words shouldBe listFrom("ptr_test_1_ev_expected.wli")
+    }
+
+    "Server mode returns an error if rule application failed" {
+        val response = runServer("test/test_all_errors.lsc", ServerRequest(listFrom("test_all_errors.wli")))
+        response.shouldBeInstanceOf<ServerResponse.Error>()
+    }
+
+    "Server mode can do tracing" {
+        val response = runServer(
+            "test/muipidan.lsc", ServerRequest(listOf("manaka"), traceWords = listOf("manaka"))
+        )
+        response.shouldBeInstanceOf<ServerResponse.Changed>()
+        response.words shouldBe listOf("manga")
+        response.traceLines shouldBe listOf(
+            "Tracing manaka",
+            "Applied first-syllable-stress: manaka -> mˈanaka",
+            "Applied syncope: mˈanaka -> mˈanka",
+            "Applied remove-stress: mˈanka -> manka",
+            "Applied consonant-coalescence: manka -> maᵑga",
+            "Applied Romanizer: maᵑga -> manga"
+        )
+    }
+})


### PR DESCRIPTION
Adds a server mode to Lexurgy, where requested and responses are formatted as JSON and sent via stdin and stdout (respectively).
Request format:
```
{"words": ["word1", "word2"], "startAt": "rule1", "stopBefore": "rule2", "traceWords": ["word2"], "romanize": false}
```
All fields other than `"words"` are optional.

Response format is either a successful change:
```
{"type": "changed", "words": ["word1 changed", "word2 changed"], "intermediates": {"intermediate1": ["word1 interim", "word2 interim"]}, "traceLines": ["Tracing word1", "Applied rule1: word1 -> word1 interim"]}
```

Or an error:
```
{"type": "error", "message": "Rule application failed...", "stackTrace": [...]}
```

I tested this in my own project and saw speed-ups of ~20x per query.