### PR TITLE
Fix include when the main path is just a filename

### DIFF
--- a/.idea/runConfigurations/CLI_tests.xml
+++ b/.idea/runConfigurations/CLI_tests.xml
@@ -15,6 +15,8 @@
           <option value="TestCLI" />
           <option value="--tests" />
           <option value="TestSoundChangerWithFiles" />
+          <option value="--tests" />
+          <option value="TestSoundChangerWithIncludedFiles" />
         </list>
       </option>
       <option name="vmOptions" value="" />
@@ -22,6 +24,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <ForceTestExec>false</ForceTestExec>
     <method v="2" />
   </configuration>
 </component>

--- a/src/jvmMain/kotlin/com/meamoria/lexurgy/sc/SoundChangesFileLoader.kt
+++ b/src/jvmMain/kotlin/com/meamoria/lexurgy/sc/SoundChangesFileLoader.kt
@@ -29,7 +29,7 @@ class SoundChangesFileLoader {
                     continue
                 }
                 val includedPath = match.groupValues[1]
-                yieldAll(load(path.parent.resolve(includedPath)))
+                yieldAll(load(path.toAbsolutePath().parent.resolve(includedPath)))
             }
         }
     }

--- a/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSoundChangerWithIncludedFiles.kt
+++ b/src/jvmTest/kotlin/com/meamoria/lexurgy/sc/TestSoundChangerWithIncludedFiles.kt
@@ -4,6 +4,8 @@ import com.meamoria.lexurgy.dumpList
 import com.meamoria.lexurgy.loadList
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.io.File
+import java.io.FileInputStream
 import java.nio.file.FileSystems
 import java.nio.file.Path
 import kotlin.time.ExperimentalTime
@@ -11,6 +13,10 @@ import kotlin.time.ExperimentalTime
 @Suppress("unused")
 @ExperimentalTime
 class TestSoundChangerWithIncludedFiles : StringSpec({
+    fun String.toPath(): Path {
+        return FileSystems.getDefault().getPath(this)
+    }
+
     fun pathOf(vararg pathComponents: String): Path =
         FileSystems.getDefault().getPath("test", *pathComponents)
 
@@ -27,9 +33,27 @@ class TestSoundChangerWithIncludedFiles : StringSpec({
         return outDir
     }
 
-    val changer = soundChangerFromLscFile(pathOf("muipidan_includer.lsc"))
+    fun copyToCwd(filenames: List<String>) {
+        for (filename in filenames) {
+            val sourcePath = pathOf(filename)
+            val targetFile = File(filename)
+
+            FileInputStream(sourcePath.toFile()).use { inputStream ->
+                targetFile.outputStream().use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                }
+            }
+        }
+    }
+
+    fun deleteFromCwd(filenames: List<String>) {
+        for (filename in filenames) {
+            File(filename).delete()
+        }
+    }
 
     "A sound changer with included files should be able to process some wordlists" {
+        val changer = soundChangerFromLscFile(pathOf("muipidan_includer.lsc"))
         val outDir = prepareOutDir("basic")
         changer.changeFiles(
             listOf(pathOf("ptr_test_1.wli"), pathOf("ptr_test_2.wli")),
@@ -37,5 +61,36 @@ class TestSoundChangerWithIncludedFiles : StringSpec({
         )
         listFrom(outDir, "ptr_test_1_ev.wli") shouldBe listFrom("ptr_test_1_ev_expected.wli")
         listFrom(outDir, "ptr_test_2_ev.wli") shouldBe listFrom("ptr_test_2_ev_expected.wli")
+    }
+
+    "A sound changer can include a file in the same directory as the main file using just the filename" {
+        val changer = soundChangerFromLscFile(pathOf("muipidan_includer_relative.lsc"))
+        val outDir = prepareOutDir("basic")
+        changer.changeFiles(
+            listOf(pathOf("ptr_test_1.wli"), pathOf("ptr_test_2.wli")),
+            outDir = outDir,
+        )
+        listFrom(outDir, "ptr_test_1_ev.wli") shouldBe listFrom("ptr_test_1_ev_expected.wli")
+        listFrom(outDir, "ptr_test_2_ev.wli") shouldBe listFrom("ptr_test_2_ev_expected.wli")
+    }
+
+    "A sound changer can include a file when the change file path is just a filename" {
+        val filenames = listOf(
+            "muipidan_includer_relative.lsc",
+            "muipidan_included.lsc",
+            "muipidan_definitions.lsc",
+            "ptr_test_1.wli"
+        )
+        copyToCwd(filenames)
+
+        try {
+            val changer = soundChangerFromLscFile(
+                "muipidan_includer_relative.lsc".toPath()
+            )
+            changer.changeFiles(listOf("ptr_test_1.wli".toPath()))
+            loadList("ptr_test_1_ev.wli".toPath()) shouldBe listFrom("ptr_test_1_ev_expected.wli")
+        } finally {
+            deleteFromCwd(filenames + "ptr_test_1_ev.wli")
+        }
     }
 })

--- a/test/muipidan_definitions.lsc
+++ b/test/muipidan_definitions.lsc
@@ -1,0 +1,45 @@
+Feature Type(*cons, vowel)
+Feature Place(lab, apic, vel, glot)
+Feature Manner(stop, fric, sonor)
+Feature Nasal(*unnas, nas)
+Feature Breath(unvcd, vcd, aspir, eject)
+Feature Height(high, low)
+Feature Depth(front, cent, back)
+Feature Rounding(*unrnd, rnd)
+Feature Stress(*unstr, str)
+
+Diacritic ˈ (before) [str]
+Diacritic ʼ [eject]
+Diacritic ʰ [aspir]
+Diacritic ̥  [unvcd]
+
+Symbol p [stop unvcd lab]
+Symbol t [stop unvcd apic]
+Symbol k [stop unvcd vel]
+Symbol ʔ [stop unvcd glot]
+Symbol b [stop vcd lab]
+Symbol d [stop vcd apic]
+Symbol g [stop vcd vel]
+Symbol ᵐb [stop nas vcd lab]
+Symbol ⁿd [stop nas vcd apic]
+Symbol ᵑg [stop nas vcd vel]
+Symbol f [fric lab]
+Symbol s [fric apic]
+Symbol x [fric vel]
+Symbol h [fric glot]
+Symbol m [sonor nas vcd lab]
+Symbol n [sonor nas vcd apic]
+Symbol l [sonor apic]
+Symbol j [sonor high front unrnd]
+Symbol w [sonor high back rnd]
+
+Symbol i [vowel high front]
+Symbol e [vowel low front]
+Symbol y [vowel high front rnd]
+Symbol ø [vowel low front rnd]
+Symbol ə [vowel high cent]
+Symbol a [vowel low cent]
+Symbol ɯ [vowel high back]
+Symbol ɤ [vowel low back]
+Symbol u [vowel high back rnd]
+Symbol o [vowel low back rnd]

--- a/test/muipidan_included.lsc
+++ b/test/muipidan_included.lsc
@@ -1,0 +1,84 @@
+#include "./muipidan_definitions.lsc"
+
+Deromanizer:
+    c => x
+    ' => ʔ
+    á => ˈa
+    é => ˈe
+    í => ˈi
+    ó => ˈo
+    ú => ˈu
+
+first-syllable-stress [vowel]:
+    [] => [str] / $ _ [unstr]+ $
+
+syncope [vowel]:
+    [] => * / {_ [str], [str] _ []}
+
+# We now have predictable word-initial stress
+remove-stress:
+    [str] => [unstr]
+
+consonant-coalescence:
+    [stop !glot] [stop] => [eject] * / _ [vowel]
+    [stop !glot] [fric] => [aspir] * / _ [vowel]
+    [nas] [stop] => * [nas vcd]
+    [fric] [nas] => * [unvcd]
+    [nas] [fric] => [unvcd] *
+
+stop-voicing:
+    [stop !glot !eject !aspir] => [vcd] / [vowel] _ [vowel]
+
+cluster-reduction:
+    [nas] => * / $ _ [fric]
+    l => * / $ _ [cons]
+    [stop] => * / _ [stop]
+    n => l / [stop] _
+    [fric] => * / _ [stop]
+
+nasal-assimilation:
+    [nas] => [$Place] / _ [cons $Place]
+    n => l / _ l
+
+glottal-loss:
+    [glot] => *
+    [vowel high] => [cons sonor] / {_ [vowel], [vowel] _}
+
+vowel-harmony-by-height [vowel] propagate:
+    [vowel] => [$Height] / [vowel $Height] _
+
+final-vowel-loss:
+    [vowel] => * / [vowel] [cons !stop] _ $
+    {e, ə, u} => {i, a, o} / [vowel] [cons]* _ $
+
+coda-l:
+    l => j / _ [cons] // _ [sonor unnas]
+    l [vowel] => j * / [vowel] [cons]* [vowel] _ [cons]+ [vowel]
+
+vowel-harmony-by-frontness [vowel] propagate:
+    [vowel !cent] => [$Depth] / [vowel !cent $Depth] [vowel cent]* _
+
+vowel-mergers:
+    {ø, ɤ, ə, ɯ} => {y, ɨ, ɨ, ɨ} // _ $
+    {ø, ɯ} => {ə, ə} / _ $
+
+velar-fricative:
+    x => h
+
+Romanizer:
+    pʼ => p'
+    tʼ => t'
+    kʼ => k'
+    pʰ => ph
+    tʰ => th
+    kʰ => kh
+    ᵐb => mb
+    ⁿd => nd
+    ᵑg => ng
+    m̥ => hm
+    n̥ => hn
+    ə => e
+    j => y
+    y => ü
+    ɨ => ï
+    f => v / {[vowel], [sonor]} _ {[vowel], [sonor]}

--- a/test/muipidan_includer_relative.lsc
+++ b/test/muipidan_includer_relative.lsc
@@ -1,0 +1,1 @@
+#include "muipidan_included.lsc"


### PR DESCRIPTION
Fixes NullPointerException when the main sound change file is given as a bare file name and it tries to include another file.

This should supersede #69; it implements the same fix in a slightly cleaner way, and adds test cases to verify the behaviour.