### PR TITLE
Support reloading sound changes in server mode

### DIFF
--- a/cli/src/main/kotlin/com/meamoria/lexurgy/cli/Application.kt
+++ b/cli/src/main/kotlin/com/meamoria/lexurgy/cli/Application.kt
@@ -8,6 +8,9 @@ import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 
+class LscUnsupportedDirective() : LscUserError(
+    "Include directives are not supported in load_string requests"
+)
 
 @ExperimentalTime
 fun changeFiles(
@@ -46,7 +49,10 @@ fun changeFiles(
 fun soundChangerFromLscFile(path: Path): SoundChanger =
     SoundChanger.fromLsc(SoundChangesFileLoader().load(path).joinToString("\n"))
 
-
+fun soundChangerFromString(string: String): SoundChanger {
+    SoundChangesFileLoader.INCLUDE_LINE.containsMatchIn(string) && throw LscUnsupportedDirective()
+    return SoundChanger.fromLsc(string)
+}
 
 @ExperimentalTime
 fun SoundChanger.changeFiles(

--- a/cli/src/main/kotlin/com/meamoria/lexurgy/cli/Main.kt
+++ b/cli/src/main/kotlin/com/meamoria/lexurgy/cli/Main.kt
@@ -164,8 +164,8 @@ class Server : CliktCommand(
     @ExperimentalTime
     override fun run() {
         runErrorProne(true) {
-            // This is somewhat janky, but I don't think we can specify an optional
-            // *positional* argument, otherwise do that instead.
+            // An empty string wouldn’t be a valid path anyway and is thus used
+            // to indicate that no `CHANGES` argument was supplied.
             runServer(if (changes.toString() == "") null else changes)
         }
     }

--- a/cli/src/main/kotlin/com/meamoria/lexurgy/cli/server/Server.kt
+++ b/cli/src/main/kotlin/com/meamoria/lexurgy/cli/server/Server.kt
@@ -1,5 +1,6 @@
 package com.meamoria.lexurgy.cli.server
 
+import com.meamoria.lexurgy.LscUserError
 import com.meamoria.lexurgy.cli.soundChangerFromLscFile
 import com.meamoria.lexurgy.cli.soundChangerFromString
 import com.meamoria.lexurgy.sc.SoundChanger
@@ -10,6 +11,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import java.nio.file.Path
 import java.nio.file.Paths
+
+class LscNoSoundChangesLoaded : LscUserError("No sound changer loaded.")
 
 @Serializable
 sealed class ServerRequest {
@@ -64,7 +67,7 @@ data class StringCollector(val strings: MutableList<String> = mutableListOf()) :
 }
 
 fun applyChanges(changer: SoundChanger?, request: ApplyChangesRequest) {
-    if (changer == null) throw Exception("No sound changer loaded.")
+    if (changer == null) throw LscNoSoundChangesLoaded()
     val collector = StringCollector()
     val intermediates = changer.changeWithIntermediates(
         request.words,
@@ -95,7 +98,6 @@ fun runServer(changes: Path?) {
 
             // For backwards-compatibility, allow the request type to be omitted. We
             // default to a request type of APPLY_CHANGES in that case.
-            // TODO: Consider emitting a deprecation warning for this?
             if (request.jsonObject["type"] == null) {
                 applyChanges(
                     changer,

--- a/cli/src/test/kotlin/com/meamoria/lexurgy/cli/TestServerModeCLI.kt
+++ b/cli/src/test/kotlin/com/meamoria/lexurgy/cli/TestServerModeCLI.kt
@@ -130,6 +130,12 @@ class TestServerModeCLI : StringSpec({
         response.shouldBeInstanceOf<ServerResponse.Error>()
     }
 
+    "Server mode errors if asked to apply changes when none are loaded".config(enabled = !Platform.isWindows()) {
+        val responses = runRequests(ApplyChangesRequest(listOf("foo")))
+        val err = responses[0].shouldBeInstanceOf<ServerResponse.Error>()
+        err.message shouldBe LscNoSoundChangesLoaded().message
+    }
+
     "Server mode errors on #include directives in a load_string request".config(enabled = !Platform.isWindows()) {
         val responses = runRequests(LoadChangesFromStringRequest("#include \"empty.lsc\""))
         val err = responses[0].shouldBeInstanceOf<ServerResponse.Error>()

--- a/cli/src/test/kotlin/com/meamoria/lexurgy/cli/TestServerModeCLI.kt
+++ b/cli/src/test/kotlin/com/meamoria/lexurgy/cli/TestServerModeCLI.kt
@@ -1,18 +1,17 @@
 package com.meamoria.lexurgy.cli
 
-import com.meamoria.lexurgy.cli.server.ServerRequest
-import com.meamoria.lexurgy.cli.server.ServerResponse
+import com.meamoria.lexurgy.cli.server.*
 import com.sun.jna.Platform
 import io.kotest.core.spec.style.StringSpec
-import kotlinx.serialization.json.Json
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.FileSystems
 import java.nio.file.Path
+import kotlin.io.path.readText
 import kotlin.time.ExperimentalTime
 
 @Suppress("unused")
@@ -41,27 +40,106 @@ class TestServerModeCLI : StringSpec({
         return outStream.toString()
     }
 
-    fun runServer(changes: String, request: ServerRequest): ServerResponse {
-        val response = withStd(Json.encodeToString(request)) {
-            lexurgyCommand.parse(arrayOf("server", changes))
-        }
+    fun runServer(changes: String, request: String): ServerResponse {
+        val response = withStd(request) { lexurgyCommand.parse(arrayOf("server", changes)) }
         return Json.decodeFromString<ServerResponse>(response)
     }
 
-    "Server mode can do sound changes from a request".config(enabled = !Platform.isWindows()) {
-        val response = runServer("test/muipidan.lsc", ServerRequest(listFrom("ptr_test_1.wli")))
+    fun runRequests(vararg requests: ServerRequest): List<ServerResponse> {
+        val responses = withStd(requests.joinToString("\n") { it.encode() }) { lexurgyCommand.parse(arrayOf("server")) }
+        return responses.split("\n").filter { it.isNotEmpty() }.map { Json.decodeFromString<ServerResponse>(it) }
+    }
+
+    fun checkWords(response: ServerResponse, file: String) {
         response.shouldBeInstanceOf<ServerResponse.Changed>()
-        response.words shouldBe listFrom("ptr_test_1_ev_expected.wli")
+        response.words shouldBe listFrom(file)
+    }
+
+
+    "Server mode can do sound changes from a request".config(enabled = !Platform.isWindows()) {
+        val response = runServer(
+            "test/muipidan.lsc",
+            ApplyChangesRequest(listFrom("ptr_test_1.wli")).encode()
+        )
+
+        checkWords(response, "ptr_test_1_ev_expected.wli")
+    }
+
+    "Server mode supports legacy request format".config(enabled = !Platform.isWindows()) {
+        val response = runServer(
+            "test/muipidan.lsc",
+            Json.encodeToString(
+                // Use this here so the `type` field is omitted.
+                ApplyChangesRequest.serializer(),
+                ApplyChangesRequest(listFrom("ptr_test_1.wli"))
+            )
+        )
+        checkWords(response, "ptr_test_1_ev_expected.wli")
     }
 
     "Server mode returns an error if rule application failed".config(enabled = !Platform.isWindows()) {
-        val response = runServer("test/test_all_errors.lsc", ServerRequest(listFrom("test_all_errors.wli")))
+        val response = runServer(
+            "test/test_all_errors.lsc",
+            ApplyChangesRequest(listFrom("test_all_errors.wli")).encode()
+        )
         response.shouldBeInstanceOf<ServerResponse.Error>()
+    }
+
+    "Server mode supports loading changes from file".config(enabled = !Platform.isWindows()) {
+        val responses = runRequests(
+            LoadChangesFromFileRequest("test/empty.lsc"),
+            ApplyChangesRequest(listFrom("ptr_test_1.wli")),
+            LoadChangesFromFileRequest("test/muipidan.lsc"),
+            ApplyChangesRequest(listFrom("ptr_test_1.wli")),
+            ApplyChangesRequest(listFrom("ptr_test_2.wli"))
+        )
+        responses[0].shouldBeInstanceOf<ServerResponse.Ok>()
+        checkWords(responses[1], "ptr_test_1.wli")
+        responses[2].shouldBeInstanceOf<ServerResponse.Ok>()
+        checkWords(responses[3], "ptr_test_1_ev_expected.wli")
+        checkWords(responses[4], "ptr_test_2_ev_expected.wli")
+    }
+
+    "Server mode supports loading changes from a string".config(enabled = !Platform.isWindows()) {
+        val responses = runRequests(
+            LoadChangesFromStringRequest(Path.of("test/empty.lsc").readText()),
+            ApplyChangesRequest(listFrom("ptr_test_1.wli")),
+            LoadChangesFromStringRequest(Path.of("test/muipidan.lsc").readText()),
+            ApplyChangesRequest(listFrom("ptr_test_1.wli")),
+            ApplyChangesRequest(listFrom("ptr_test_2.wli"))
+        )
+        responses[0].shouldBeInstanceOf<ServerResponse.Ok>()
+        checkWords(responses[1], "ptr_test_1.wli")
+        responses[2].shouldBeInstanceOf<ServerResponse.Ok>()
+        checkWords(responses[3], "ptr_test_1_ev_expected.wli")
+        checkWords(responses[4], "ptr_test_2_ev_expected.wli")
+    }
+
+    "Server mode errors on invalid lsc file".config(enabled = !Platform.isWindows()) {
+        val responses = runRequests(LoadChangesFromStringRequest("garbage"))
+        responses[0].shouldBeInstanceOf<ServerResponse.Error>()
+    }
+
+    "Server mode errors on invalid request type".config(enabled = !Platform.isWindows()) {
+        val response = runServer("", """{"type": "garbage", "data": {}}""")
+        response.shouldBeInstanceOf<ServerResponse.Error>()
+    }
+
+    "Server mode errors on missing request data".config(enabled = !Platform.isWindows()) {
+        val response = runServer("", """{"type": "apply"}""")
+        response.shouldBeInstanceOf<ServerResponse.Error>()
+    }
+
+    "Server mode errors on #include directives in a load_string request".config(enabled = !Platform.isWindows()) {
+        val responses = runRequests(LoadChangesFromStringRequest("#include \"empty.lsc\""))
+        val err = responses[0].shouldBeInstanceOf<ServerResponse.Error>()
+        err.message shouldBe LscUnsupportedDirective().message
     }
 
     "Server mode can do tracing".config(enabled = !Platform.isWindows()) {
         val response = runServer(
-            "test/muipidan.lsc", ServerRequest(listOf("manaka"), traceWords = listOf("manaka"))
+            "test/muipidan.lsc",
+            ApplyChangesRequest(listOf("manaka"), traceWords = listOf("manaka")).encode(),
         )
         response.shouldBeInstanceOf<ServerResponse.Changed>()
         response.words shouldBe listOf("manga")


### PR DESCRIPTION
This adds two additional request types to the CLI’s `server` mode to enable (re)loading a new set of sound changes from a file or directly from the request. Essentially, you can now do this:
```
{"type": "load_string", "data": {"path": "sound changes go here" }}
```
I’ve also made the `CHANGES` parameter optional now that you can load the changes after starting the server. Furthermore, the previous request format was not exactly amenable to extension, so I’ve refactored it to use a `type`+`data` schema. The old request format with all the data at the top level is still supported for backwards compatibility, albeit not for any of the new requests.

I personally need this feature for a project I’m working on, so I thought I might as well upstream it in case you’re interested in it as well. I don’t typically work with Kotlin though, so I’m not sure whether my implementation of this is idiomatic or anything like that.